### PR TITLE
Add Default Community Health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug in KubeVirt
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+<!-- Make sure that you visit our User Guide at https://kubevirt.io/user-guide.
+-->
+
+**What happened**:
+A clear and concise description of what the bug is.
+
+**What you expected to happen**:
+A clear and concise description of what you expected to happen.
+
+**How to reproduce it (as minimally and precisely as possible)**:
+Steps to reproduce the behavior.
+
+**Additional context**:
+Add any other context about the problem here.
+
+**Environment**:
+- KubeVirt version (use `virtctl version`): N/A
+- Kubernetes version (use `kubectl version`): N/A
+- VM or VMI specifications: N/A
+- Cloud provider or hardware configuration: N/A
+- OS (e.g. from /etc/os-release): N/A
+- Kernel (e.g. `uname -a`): N/A
+- Install tools: N/A
+- Others: N/A

--- a/.github/ISSUE_TEMPLATE/docs_report.md
+++ b/.github/ISSUE_TEMPLATE/docs_report.md
@@ -1,0 +1,22 @@
+---
+name: Docs Report
+about: Report an issue in KubeVirt's documentation
+title: ''
+labels: ''
+assignees: ''
+
+---
+<!-- Make sure that you visit our User Guide at https://kubevirt.io/user-guide.
+-->
+
+**Description**:
+A clear and concise description of what the issue is.
+
+**What you expected**:
+A clear and concise description of what you expected.
+
+**URL**:
+Provide a link to the documentation.
+
+**Additional context**:
+Add any other context about the issue here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest an idea for KubeVirt
+title: ''
+labels: kind/enhancement
+assignees: ''
+
+---
+<!-- Make sure that you visit our User Guide at https://kubevirt.io/user-guide.
+-->
+
+**Is your feature request related to a problem? Please describe**:
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**:
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**:
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**:
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
+2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Checklist**
+
+This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
+Approvers are expected to review this list.
+
+- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
+- [ ] PR: The PR description is expressive enough and will help future contributors
+- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
+- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
+- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
+- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
+- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
+- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, just write "NONE".
+-->
+```release-note
+
+```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+Community Code of Conduct
+=========================
+We want to keep the KubeVirt Community a great place to participate, but we need your help to keep it that way.
+
+The KubeVirt community is made up of a diverse mix of individuals using and contributing to all aspects of the project from all over the world, and we want to make sure that the community is a safe and friendly place for everyone.
+
+As a CNCF project, KubeVirt and its community abide by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+Should you encounter a violation of this Code of Conduct, please report it to the [KubeVirt Maintainers private email alias](mailto:cncf-kubevirt-maintainers@cncf.io).  If the CoC violation involves a member of [the Maintainers](https://github.com/kubevirt/community/blob/main/MAINTAINERS.md), please escalate the report to [the CNCF Conduct staff](mailto:conduct@cncf.io).  All reports will be kept confidential.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Introduction
+
+Let's start with the relationship between the two important components:
+
+* **Kubernetes** is a container orchestration system, and is used to run
+  containers on a cluster
+* **KubeVirt** is an add-on which is installed on-top of Kubernetes, to be able
+  to add basic virtualization functionality to Kubernetes.
+
+KubeVirt is an add-on to Kubernetes, and they have several things in
+common:
+
+* Mostly written in golang
+* Often related to distributed microservice architectures
+* Declarative and Reactive (Operator pattern) approach
+
+This short page shall help to get started with the projects and topics
+surrounding them
+
+
+## Contributing to KubeVirt
+
+### Our workflow
+
+Contributing to KubeVirt should be as simple as possible. Have a question? Want
+to discuss something? Want to contribute something? Just open an
+[Issue](https://github.com/kubevirt/kubevirt/issues), a [Pull
+Request](https://github.com/kubevirt/kubevirt/pulls), or send a mail to our
+[Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev).
+
+If you spot a bug or want to change something pretty simple, just go
+ahead and open an Issue and/or a Pull Request, including your changes
+at [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt).
+
+For larger changes that require more planning and discussion, using the KubeVirt
+[design proposal template](https://github.com/kubevirt/community/blob/main/design-proposals/proposal-template.md) is highly encouraged.
+The technical effort for these changes will impact a large section of the
+development community, so they should be communicated widely.  Examples of these types
+of changes:
+- New APIs
+- Architectural changes
+- Code refactors
+- API changes
+
+### Getting started
+
+To make yourself comfortable with the code, you might want to work on some
+Issues marked with one or more of the following labels:
+[good-first-issue](https://github.com/kubevirt/kubevirt/labels/good-first-issue),
+[help-wanted](https://github.com/kubevirt/kubevirt/labels/help-wanted)
+or [kind/bug](https://github.com/kubevirt/kubevirt/labels/kind%2Fbug).
+Any help is highly appreciated.
+
+### Testing
+
+**Untested features do not exist**. To ensure that what the code really works,
+relevant flows should be covered via unit tests and functional tests. So when
+thinking about a contribution, also think about testability. All tests can be
+run local without the need of CI. Have a look at the
+[Testing](https://github.com/kubevirt/kubevirt/blob/main/docs/getting-started.md#testing)
+section in the [Developer Guide](https://github.com/kubevirt/kubevirt/blob/main/docs/getting-started.md).
+
+#### Automated testing of pull requests
+
+Automated testing is triggered on pull requests (PRs) opened by members of the KubeVirt organization, with the exception of _[draft pull requests](CONTRIBUTING.md#consider-opening-your-pull-request-as-draft)_. Pull requests opened by new contributors are initially marked with the label [`needs-ok-to-test`](https://github.com/kubevirt/kubevirt/labels/needs-ok-to-test) and are not automatically tested. Test lanes will be created after a member of the KubeVirt organization adds [`/ok-to-test`](https://prow.ci.kubevirt.io/command-help#ok_to_test) on the PR.
+
+For more information about our CI, please have a look at the [docs](https://github.com/kubevirt/project-infra/tree/main/docs) in the project-infra repository.
+
+#### Consider opening your pull request as draft
+Not all pull requests are ready for review when they are created. This might be because the author wants to initiate a conversation or they might not be entirely sure whether the changes go in the right direction, or even because the changes are not complete.
+
+Please consider creating such PRs as [Draft Pull Requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/). Draft PRs are skipped by CI, which saves CI resources. It also means that reviewers are not automatically assigned and the community will understand that this PR is not yet ready for review.
+
+After you mark your draft pull request as ready for review, reviewers will be assigned and tests will be triggered if the ok-to-test label is present (see [above](CONTRIBUTING.md#automated-testing-of-pull-requests)).
+
+**Note that organization members can always trigger lanes manually by commenting [`/test`](https://prow.ci.kubevirt.io/command-help#test) on the pull request.**
+
+### Contributor compliance with Developer Certificate Of Origin (DCO)
+
+We require every contributor to certify that they are legally permitted to contribute to our project.
+A contributor expresses this by consciously signing their commits, and by this act expressing that
+they comply with the [Developer Certificate Of Origin](https://developercertificate.org/)
+
+A signed commit is a commit where the commit message contains the following content:
+
+```
+Signed-off-by: John Doe <jdoe@example.org>
+```
+
+This can be done by adding [`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to your git command line.
+
+### Getting your code reviewed/merged
+
+Maintainers are here to help you enabling your use-case in a reasonable amount
+of time. The maintainers will try to review your code and give you productive
+feedback in a reasonable amount of time. However, if you are blocked on a
+review, or your Pull Request does not get the attention you think it deserves,
+reach out for us via Comments in your Issues, or ping us on Slack
+[#kubevirt-dev @ kubernetes.slack.com](https://kubernetes.slack.com/?redir=%2Farchives%2FC0163DT0R8X).
+
+Maintainers are tracked in [OWNERS
+files](https://github.com/kubernetes/test-infra/blob/f7e21a3c18f4f4bbc7ee170675ed53e4544a0632/prow/plugins/approve/approvers/README.md)
+and will be assigned by Prow.
+
+### Becoming a member
+
+Contributors that frequently contribute to the project may ask to join the
+KubeVirt organization.
+
+Please have a look at our [membership guidelines](https://github.com/kubevirt/community/blob/main/membership_policy.md).
+
+## Projects & Communities
+
+### [KubeVirt](https://github.com/kubevirt/)
+
+* Getting started
+  * [Developer Guide](https://github.com/kubevirt/kubevirt/blob/main/docs/getting-started.md)
+  * [Demo](https://github.com/kubevirt/demo)
+  * [Documentation](https://github.com/kubevirt/kubevirt/tree/main/docs)
+
+### [Kubernetes](http://kubernetes.io/)
+
+* Getting started
+  * [http://kubernetesbyexample.com](http://kubernetesbyexample.com)
+  * [Hello Minikube - Kubernetes](https://kubernetes.io/docs/tutorials/stateless-application/hello-minikube/)
+  * [User Guide - Kubernetes](https://kubernetes.io/docs/user-guide/)
+* Details
+  * [Declarative Management of Kubernetes Objects Using Configuration Files - Kubernetes](https://kubernetes.io/docs/concepts/tools/kubectl/object-management-using-declarative-config/)
+  * [Kubernetes Architecture](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/architecture.md)
+
+## Additional Topics
+
+* Golang
+  * [Documentation - The Go Programming Language](https://go.dev/doc/)
+  * [Getting Started - The Go Programming Language](https://go.dev/doc/install)
+* Patterns
+  * [Introducing Operators: Putting Operational Knowledge into Software](https://web.archive.org/web/20210210032403/https://coreos.com/blog/introducing-operators.html)
+  * [Microservices](https://martinfowler.com/articles/microservices.html) nice
+    content by Martin Fowler
+* Testing
+  * [Ginkgo - A Golang BDD Testing Framework](https://onsi.github.io/ginkgo/)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,107 @@
+# Project Governance
+
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Voting](#voting)
+
+## Maintainers
+
+KubeVirt Maintainers govern the project. Maintainers collectively manage the 
+project's resources and contributors, and speak for the project in public.  The
+maintainers collectively decide any questions that cannot be resolved at the 
+individual repository level, and provide strategic guidance for the project
+overall.
+
+The current maintainers can be found in [MAINTAINERS](https://github.com/kubevirt/community/blob/main/MAINTAINERS.md).  
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the KubeVirt project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues.
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+## Selecting Maintainers
+
+The current project maintainers will periodically review contributor activities
+to see if additional project members may be promoted to maintainers. 
+
+For nominations, the maintainers will look at the following criteria:
+
+  * Commitment to the project: have they participated in discussions, 
+    contributions, and reviews for 1 year or more?
+  * Does the person show leadership in one of these areas?
+    * Active approver or reviewer in core or subprojects
+    * SIG leadership
+    * Mentoring other project contributors
+  * Does the candidate bring new perspectives or community connections to the 
+    maintainers?
+  * Do they understand how the project works (policies, processes, etc)?
+  * Are they willing to take on the additional duties of a maintainer?
+
+A candidate must be proposed by an existing maintainer by filing an PR in the
+[Community Repo](https://github.com/kubevirt/community) against the MAINTAINERS.md file. 
+A simple majority vote of +1s from existing Maintainers approves the application. 
+Approved maintainers will be added to the [private maintainer mailing list](mailto:cncf-kubevirt-maintainers@lists.cncf.io).
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the weekly public
+community meeting. 
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## CNCF Resources
+
+Any Maintainer may suggest a request for CNCF resources, in the
+[developer mailing list](https://groups.google.com/forum/#!forum/kubevirt-dev), 
+the [Maintainer mailing list](mailto:cncf-kubevirt-maintainers@lists.cncf.io), on Github, 
+or during a community meeting.  A simple majority of Maintainers approves the 
+request.  The Maintainers may also choose to delegate working with the CNCF to 
+non-Maintainer community members.
+
+## Code of Conduct
+
+[Code of Conduct](https://github.com/kubevirt/.github/blob/main/CODE_OF_CONDUCT.md)
+violations by community members will be discussed and resolved
+on the [private Maintainer mailing list](mailto:cncf-kubevirt-maintainers@lists.cncf.io).  If the reported CoC violator
+is a Maintainer, the Maintainers will instead designate two Maintainers to work
+with CNCF staff in resolving the report.
+
+## Removing Maintainers
+
+Maintainers may voluntarily retire at any time.  Should a maintainer retire, 
+it requires a majority vote of the current maintainers to reinstate them.
+
+Maintainers may also be demoted at any time for one of the following reasons:
+
+* Inactivity, including 6 months or more of non-participation or non-communication,
+* Refusal to abide by this Governance,
+* Violations of the Code of Conduct,
+* Other actions that harm the reputation, stability, or harmony of the Kubevirt
+  project.
+
+Removing a maintainer requires a 2/3 majority vote of the other maintainers.
+
+## Voting
+
+While most business in KubeVirt is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](https://groups.google.com/forum/#!forum/kubevirt-dev) or
+the private Maintainer mailing list for security or conduct matters.  
+Votes may also be taken at the community meeting.  Any Maintainer may
+request a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, and changes to this
+Governance require a 2/3 vote of all Maintainers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The KubeVirt project treats security vulnerabilities seriously, so we
+strive to take action quickly when required.
+
+The project requests that security issues be disclosed in a responsible
+manner to allow adequate time to respond.  If a security issue or
+vulnerability has been found, please disclose the details to our
+dedicated email address:
+
+cncf-kubevirt-security@lists.cncf.io
+
+Please include as much information as possible with the report. The
+following details assist with analysis efforts:
+  - Description of the vulnerability
+  - Affected component (version, commit, branch etc)
+  - Affected code (file path, line numbers)
+  - Exploit code
+
+Any confidential information disclosed to the security team will be
+handled appropriately to prevent misuse or accidental disclosure.
+
+## Security Notices
+
+Security notices will be sent to the kubevirt-dev@googlegroups.com
+mailing list and published to the
+[Security Advisories](https://github.com/kubevirt/kubevirt/security/advisories)
+page.
+
+## Security Team
+
+The security team currently consists of the Maintainers of KubeVirt and is
+supported by security teams of involved vendors.
+
+List of involved vendor security teams:
+- Red Hat <secalert@redhat.com>
+- SUSE <security@suse.de>
+
+## Alternate Reporting Mechanism
+
+If you are unable to report the vulnerability to the dedicated email address, you can use the [GitHub vulnerability report mechanism](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). 


### PR DESCRIPTION
Motive of this PR is to create default community health files like `code-of-conduct.md`, `governance.md`, etc. Please refer to [this issue](https://github.com/kubevirt/community/issues/235) and also see the discussion done in [this PR](https://github.com/kubevirt/project-infra/pull/3078).